### PR TITLE
Get table name from config file

### DIFF
--- a/src/Repat/LaravelJobs/Job.php
+++ b/src/Repat/LaravelJobs/Job.php
@@ -2,6 +2,8 @@
 
 namespace Repat\LaravelJobs;
 
+use Illuminate\Support\Facades\Config;
+
 class Job extends \Illuminate\Database\Eloquent\Model
 {
     use Attributes;
@@ -14,4 +16,10 @@ class Job extends \Illuminate\Database\Eloquent\Model
         'available_at' => 'datetime',
         'created_at' => 'datetime',
     ];
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->table = Config::get('queue.connections.' . (Config::get('queue.default', 'database')) . '.table', 'jobs');
+    }
 }

--- a/src/Repat/LaravelJobs/JobFail.php
+++ b/src/Repat/LaravelJobs/JobFail.php
@@ -2,6 +2,8 @@
 
 namespace Repat\LaravelJobs;
 
+use Illuminate\Support\Facades\Config;
+
 class JobFail extends \Illuminate\Database\Eloquent\Model
 {
     use Attributes;
@@ -12,4 +14,10 @@ class JobFail extends \Illuminate\Database\Eloquent\Model
         'payload' => 'array',
         'failed_at' => 'datetime',
     ];
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->table = Config::get('queue.failed.table', 'job_fails');
+    }
 }


### PR DESCRIPTION
Package raises an error when table name is not set to default. This pull request should fix it by getting active jobs / failed_jobs table names from config file.